### PR TITLE
取消写死的 redisSerializer，以及对 NullValue 的特殊处理

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,16 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-web</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>com.github.ben-manes.caffeine</groupId>

--- a/src/main/java/com/pig4cloud/plugin/cache/MultilevelCacheAutoConfiguration.java
+++ b/src/main/java/com/pig4cloud/plugin/cache/MultilevelCacheAutoConfiguration.java
@@ -3,6 +3,8 @@ package com.pig4cloud.plugin.cache;
 import com.pig4cloud.plugin.cache.properties.CacheConfigProperties;
 import com.pig4cloud.plugin.cache.support.CacheMessageListener;
 import com.pig4cloud.plugin.cache.support.RedisCaffeineCacheManager;
+import com.pig4cloud.plugin.cache.support.RedisCaffeineCaffeineCacheManagerCustomizer;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -15,7 +17,10 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.serializer.RedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.util.Objects;
 
 /**
  * @author fuwei.deng
@@ -27,10 +32,15 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class MultilevelCacheAutoConfiguration {
 
 	@Bean
+	@ConditionalOnMissingBean
 	@ConditionalOnBean(RedisTemplate.class)
 	public RedisCaffeineCacheManager cacheManager(CacheConfigProperties cacheConfigProperties,
-			@Qualifier("stringKeyRedisTemplate") RedisTemplate<Object, Object> stringKeyRedisTemplate) {
-		return new RedisCaffeineCacheManager(cacheConfigProperties, stringKeyRedisTemplate);
+			@Qualifier("stringKeyRedisTemplate") RedisTemplate<Object, Object> stringKeyRedisTemplate,
+			ObjectProvider<RedisCaffeineCaffeineCacheManagerCustomizer> cacheManagerCustomizers) {
+		RedisCaffeineCacheManager cacheManager = new RedisCaffeineCacheManager(cacheConfigProperties,
+				stringKeyRedisTemplate);
+		cacheManagerCustomizers.orderedStream().forEach(customizer -> customizer.customize(cacheManager));
+		return cacheManager;
 	}
 
 	/**
@@ -47,15 +57,26 @@ public class MultilevelCacheAutoConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(name = "cacheMessageListenerContainer")
 	public RedisMessageListenerContainer cacheMessageListenerContainer(CacheConfigProperties cacheConfigProperties,
 			@Qualifier("stringKeyRedisTemplate") RedisTemplate<Object, Object> stringKeyRedisTemplate,
-			RedisCaffeineCacheManager redisCaffeineCacheManager) {
+			@Qualifier("cacheMessageListener") CacheMessageListener cacheMessageListener) {
 		RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
-		redisMessageListenerContainer.setConnectionFactory(stringKeyRedisTemplate.getConnectionFactory());
-		CacheMessageListener cacheMessageListener = new CacheMessageListener(redisCaffeineCacheManager);
+		redisMessageListenerContainer
+				.setConnectionFactory(Objects.requireNonNull(stringKeyRedisTemplate.getConnectionFactory()));
 		redisMessageListenerContainer.addMessageListener(cacheMessageListener,
 				new ChannelTopic(cacheConfigProperties.getRedis().getTopic()));
 		return redisMessageListenerContainer;
+	}
+
+	@Bean
+	@SuppressWarnings("unchecked")
+	@ConditionalOnMissingBean(name = "cacheMessageListener")
+	public CacheMessageListener cacheMessageListener(
+			@Qualifier("stringKeyRedisTemplate") RedisTemplate<Object, Object> stringKeyRedisTemplate,
+			RedisCaffeineCacheManager redisCaffeineCacheManager) {
+		return new CacheMessageListener((RedisSerializer<Object>) stringKeyRedisTemplate.getValueSerializer(),
+				redisCaffeineCacheManager);
 	}
 
 }

--- a/src/main/java/com/pig4cloud/plugin/cache/config/CacheJackson2ObjectMapperBuilderCustomizer.java
+++ b/src/main/java/com/pig4cloud/plugin/cache/config/CacheJackson2ObjectMapperBuilderCustomizer.java
@@ -1,0 +1,67 @@
+package com.pig4cloud.plugin.cache.config;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.pig4cloud.plugin.cache.support.CacheMessage;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.cache.support.NullValue;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+/**
+ * 为 jackson 添加序列化和反序列化 NullValue, CacheMessage 支持
+ *
+ * @author FlyInWind
+ */
+@Configuration(proxyBeanMethods = false)
+@ConditionalOnClass(Jackson2ObjectMapperBuilder.class)
+public class CacheJackson2ObjectMapperBuilderCustomizer implements Jackson2ObjectMapperBuilderCustomizer {
+
+	@Override
+	public void customize(Jackson2ObjectMapperBuilder builder) {
+		// 由于 NullValue 有 final 修饰，而 jackson 配置的是 NON_FINAL
+		// 会导致 @class 信息不会添加到 json 中，序列化出来的 json 为空，最终报错
+		// 这里利用 ObjectMapper 的 mixIn 强制添加 @class 信息
+		builder.mixIn(NullValue.class, UseTypeInfo.class);
+		// 反序列化会创建新的对象，而由于 NullValue#equal 方法仅通过 == 判断是否相等，会导致 equal 结果为 false
+		// 这里新建一个 Deserializer 专门返回 NullValue.INSTANCE
+		builder.deserializers(NullValueDeserializer.INSTANCE);
+
+		// CacheMessage需要通过有参构造器构造
+		builder.mixIn(CacheMessage.class, CacheMessageMix.class);
+	}
+
+	public static class NullValueDeserializer extends StdDeserializer<NullValue> {
+
+		public static final NullValueDeserializer INSTANCE = new NullValueDeserializer();
+
+		protected NullValueDeserializer() {
+			super(NullValue.class);
+		}
+
+		@Override
+		public NullValue deserialize(JsonParser p, DeserializationContext ctx) {
+			return (NullValue) NullValue.INSTANCE;
+		}
+
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS)
+	public static class UseTypeInfo {
+
+	}
+
+	public static class CacheMessageMix {
+
+		@JsonCreator
+		public CacheMessageMix(@JsonProperty("cacheName") String cacheName, @JsonProperty("key") Object key) {
+		}
+
+	}
+
+}

--- a/src/main/java/com/pig4cloud/plugin/cache/support/CacheMessageListener.java
+++ b/src/main/java/com/pig4cloud/plugin/cache/support/CacheMessageListener.java
@@ -1,5 +1,6 @@
 package com.pig4cloud.plugin.cache.support;
 
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -11,21 +12,18 @@ import org.springframework.data.redis.serializer.RedisSerializer;
  * @version 1.0.0
  */
 @Slf4j
+@Getter
 @RequiredArgsConstructor
 public class CacheMessageListener implements MessageListener {
 
-	private RedisSerializer<Object> javaSerializer = RedisSerializer.java();
+	private final RedisSerializer<Object> redisSerializer;
 
 	private final RedisCaffeineCacheManager redisCaffeineCacheManager;
 
 	@Override
 	public void onMessage(Message message, byte[] pattern) {
-
-		/**
-		 * 发送端固定了jdk序列户方式，接收端同样固定了jdk序列化方式进行反序列化。
-		 */
-		CacheMessage cacheMessage = (CacheMessage) javaSerializer.deserialize(message.getBody());
-		log.debug("recevice a redis topic message, clear local cache, the cacheName is {}, the key is {}",
+		CacheMessage cacheMessage = (CacheMessage) redisSerializer.deserialize(message.getBody());
+		log.debug("receive a redis topic message, clear local cache, the cacheName is {}, the key is {}",
 				cacheMessage.getCacheName(), cacheMessage.getKey());
 		redisCaffeineCacheManager.clearLocal(cacheMessage.getCacheName(), cacheMessage.getKey());
 	}

--- a/src/main/java/com/pig4cloud/plugin/cache/support/RedisCaffeineCaffeineCacheManagerCustomizer.java
+++ b/src/main/java/com/pig4cloud/plugin/cache/support/RedisCaffeineCaffeineCacheManagerCustomizer.java
@@ -1,0 +1,17 @@
+package com.pig4cloud.plugin.cache.support;
+
+/**
+ * 修改 {@link RedisCaffeineCacheManager} 的回调
+ *
+ * @author FlyInWind
+ */
+@FunctionalInterface
+public interface RedisCaffeineCaffeineCacheManagerCustomizer {
+
+	/**
+	 * 修改 {@link RedisCaffeineCacheManager}
+	 * @param cacheManager cacheManager
+	 */
+	void customize(RedisCaffeineCacheManager cacheManager);
+
+}


### PR DESCRIPTION
我看到之前有个提交写死了 redisSerializer ，并新建了个 NullValue，感觉并不合理。
我这里删掉了那些代码，并添加了更多 public 和 protect 方法，以方便重写。另外还添加了 jackson 的配置，应该可以解决那位提交者的问题